### PR TITLE
fix redundant type warning

### DIFF
--- a/deepcopy_enum_fix2_test.go
+++ b/deepcopy_enum_fix2_test.go
@@ -71,7 +71,7 @@ func Test_Fix2(t *testing.T) {
 	var r *GetRecommendedListResp_GetRecommendedListRespData
 	resp := GetRecommendedListResp{
 		// 帮我优化这个代码
-		List:    []*SquareDiaryItemSrc{&SquareDiaryItemSrc{ResourceType: DiaryResourceType_DiaryResourceTypeVideo}},
+		List:    []*SquareDiaryItemSrc{{ResourceType: DiaryResourceType_DiaryResourceTypeVideo}},
 		HasMore: true,
 		Pos:     10,
 		Offset:  11,

--- a/deepcopy_map_test.go
+++ b/deepcopy_map_test.go
@@ -48,9 +48,9 @@ func Test_Map_Special(t *testing.T) {
 		// map里面的值是结构体
 		func() testCase {
 			src := map[string]mVal{
-				"1": mVal{ID: 1, Name: "name:1"},
-				"2": mVal{ID: 2, Name: "name:2"},
-				"3": mVal{ID: 3, Name: "name:3"},
+				"1": {ID: 1, Name: "name:1"},
+				"2": {ID: 2, Name: "name:2"},
+				"3": {ID: 3, Name: "name:3"},
 			}
 
 			var dst map[string]mVal
@@ -60,7 +60,7 @@ func Test_Map_Special(t *testing.T) {
 		// dst的地址不是指针，没有发生panic
 		func() testCase {
 			src := map[string]mVal{
-				"1": mVal{ID: 1, Name: "name:1"},
+				"1": {ID: 1, Name: "name:1"},
 			}
 
 			var dst map[string]mVal
@@ -69,7 +69,7 @@ func Test_Map_Special(t *testing.T) {
 		}(),
 		func() testCase {
 			src := map[string]mVal{
-				"1": mVal{ID: 1, Name: "name:1"},
+				"1": {ID: 1, Name: "name:1"},
 			}
 
 			Copy(new(int), &src).Do()


### PR DESCRIPTION
This PR removes redundant type declarations, to enhance readability and adherence to Go's idiomatic style.